### PR TITLE
Telegraf Deployment, Service 

### DIFF
--- a/grafana/01-telegraf-dashboard.json
+++ b/grafana/01-telegraf-dashboard.json
@@ -1,0 +1,4106 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:208",
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "SNMP Telegraf Prometheus Dashboard to Monitor Dell Hosts with iDRAC",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 182,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "iDRAC Summary",
+      "type": "row"
+    },
+    {
+      "clockType": "24 hour",
+      "countdownSettings": {
+        "endCountdownTime": "2020-04-10T22:05:00.000Z",
+        "endText": "00:00:00"
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "dateSettings": {
+        "dateFormat": "YYYY-MM-DD",
+        "fontSize": "20px",
+        "fontWeight": "normal",
+        "showDate": false
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 0,
+        "y": 9
+      },
+      "id": 213,
+      "links": [],
+      "mode": "time",
+      "options": {
+        "bgColor": "",
+        "clockType": "24 hour",
+        "countdownSettings": {
+          "endCountdownTime": "2022-05-16T03:26:04-04:00",
+          "endText": "00:00:00"
+        },
+        "countupSettings": {
+          "beginCountupTime": "2022-05-16T03:26:04-04:00",
+          "beginText": "00:00:00"
+        },
+        "dateSettings": {
+          "dateFormat": "YYYY-MM-DD",
+          "fontSize": "20px",
+          "fontWeight": "normal",
+          "locale": "",
+          "showDate": false
+        },
+        "mode": "time",
+        "refresh": "sec",
+        "timeSettings": {
+          "fontSize": "12px",
+          "fontWeight": "normal"
+        },
+        "timezone": "",
+        "timezoneSettings": {
+          "fontSize": "12px",
+          "fontWeight": "normal",
+          "showTimezone": false,
+          "zoneFormat": "offsetAbbv"
+        }
+      },
+      "pluginVersion": "2.1.0",
+      "refreshSettings": {
+        "syncWithDashboard": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeSettings": {
+        "customFormat": "HH:mm:ss",
+        "fontSize": "32px",
+        "fontWeight": "normal"
+      },
+      "timezoneSettings": {
+        "fontSize": "12px",
+        "fontWeight": "normal",
+        "showTimezone": false,
+        "zoneFormat": "offsetAbbv"
+      },
+      "title": "Local Time",
+      "type": "grafana-clock-panel"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 80.0003
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 2,
+        "y": 9
+      },
+      "id": 35,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 5,
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "min"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "text": {
+          "titleSize": 1
+        }
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "alias": "CPU 1 Temp",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "(avg_over_time(idrac_hosts_cpu2_temp[5m]) + avg_over_time(idrac_hosts_cpu1_temp[5m]))",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpu1-temp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 10"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "alias": "CPU 2 Temp",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpu2-temp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 10"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "AVG CPU Temp",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 10,
+        "y": 9
+      },
+      "id": 90,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "bucketOffset": 0,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "sum_over_time(idrac_hosts_power_state[5m])",
+          "groupBy": [],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "cmos-batterystate"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "CMOS Battery",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "displayMode": "color-text",
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "2": {
+                  "color": "orange",
+                  "index": 0,
+                  "text": "1 down"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 16,
+        "y": 9
+      },
+      "id": 524,
+      "interval": "",
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "alias": "[[tag_system-name]]",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_system_globalstatus) by (system_model)",
+          "groupBy": [
+            {
+              "params": [
+                "system-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-globalstatus"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Global Status Map",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 0,
+        "y": 12
+      },
+      "id": 179,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "count(idrac_hosts_system_globalstatus)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "show tag values cardinality from \"idrac-hosts\" with key = \"system-name\"",
+          "range": true,
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "# of iDRACs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-greens"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 22,
+        "x": 0,
+        "y": 15
+      },
+      "id": 6,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "repeat": "idrac_host",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(idrac_hosts_system_uptime[5m])",
+          "groupBy": [],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-uptime"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "System Uptime",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [
+                "{agent_host=\"192.168.52.167\", host=\"telegraf-custom-8664c464bb-rgcch\", idrac_url=\"https://192.168.52.167:443\", instance=\"prom-newton.apps.tme.shift.zone:80\", job=\"telegraf-agent\", system_model=\"PowerEdge R750\", system_name=\"idrac-41DRMH3\", system_servicetag=\"41DRMH3\"}",
+                "{agent_host=\"192.168.52.167\", host=\"telegraf-custom-8c49c5f86-t2pkl\", idrac_url=\"https://192.168.52.167:443\", instance=\"prom-newton.apps.tme.shift.zone:80\", job=\"telegraf-agent\", system_model=\"PowerEdge R750\", system_name=\"idrac-41DRMH3\", system_servicetag=\"41DRMH3\"}"
+              ],
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "columns": [],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 0,
+        "y": 19
+      },
+      "hideTimeOverride": false,
+      "id": 119,
+      "interval": "",
+      "pageSize": 25,
+      "repeatDirection": "h",
+      "showHeader": true,
+      "sort": {
+        "col": 1,
+        "desc": false
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:23610",
+          "alias": "",
+          "align": "center",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "Time",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:23611",
+          "alias": "System Name",
+          "align": "center",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": true,
+          "linkTooltip": "Launch iDRAC Web Interface",
+          "linkUrl": "${__cell_2:raw}",
+          "mappingType": 1,
+          "pattern": "system-name",
+          "preserveFormat": false,
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:23612",
+          "alias": "Service Tag",
+          "align": "center",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "system-servicetag",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:23613",
+          "alias": "Power State",
+          "align": "center",
+          "colorMode": "cell",
+          "colors": [
+            "#C4162A",
+            "#FA6400",
+            "#37872D"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "power-state",
+          "thresholds": [
+            "2.9",
+            "3.9"
+          ],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "$$hashKey": "object:23697",
+              "text": "Other",
+              "value": "1"
+            },
+            {
+              "$$hashKey": "object:23698",
+              "text": "Unknown",
+              "value": "2"
+            },
+            {
+              "$$hashKey": "object:23699",
+              "text": "Off",
+              "value": "3"
+            },
+            {
+              "$$hashKey": "object:23700",
+              "text": "On",
+              "value": "4"
+            }
+          ]
+        },
+        {
+          "$$hashKey": "object:23614",
+          "alias": "Global Status",
+          "align": "center",
+          "colorMode": "cell",
+          "colors": [
+            "#E0B400",
+            "#37872D",
+            "#C4162A"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "system-globalstatus",
+          "thresholds": [
+            "2.9",
+            "3.9"
+          ],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "$$hashKey": "object:23721",
+              "text": "Other",
+              "value": "1"
+            },
+            {
+              "$$hashKey": "object:23722",
+              "text": "Unknown",
+              "value": "2"
+            },
+            {
+              "$$hashKey": "object:23723",
+              "text": "Non-Critical Failure",
+              "value": "4"
+            },
+            {
+              "$$hashKey": "object:23724",
+              "text": "Critical Failure",
+              "value": "5"
+            },
+            {
+              "$$hashKey": "object:23725",
+              "text": "Non-Recoverable Failure",
+              "value": "6"
+            },
+            {
+              "$$hashKey": "object:23726",
+              "text": "OK",
+              "value": "3"
+            }
+          ]
+        },
+        {
+          "$$hashKey": "object:23615",
+          "alias": "Uptime",
+          "align": "center",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 1,
+          "mappingType": 1,
+          "pattern": "system-uptime",
+          "thresholds": [],
+          "type": "number",
+          "unit": "s"
+        },
+        {
+          "$$hashKey": "object:23616",
+          "alias": "System Model",
+          "align": "center",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "system-model",
+          "preserveFormat": false,
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:9602",
+          "alias": "iDRAC URL",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "mappingType": 1,
+          "pattern": "idrac-url",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "system-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "F",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "idrac-url"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "system-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "max(idrac_hosts_system_globalstatus)",
+          "rawQuery": false,
+          "refId": "B",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-servicetag"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "system-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-model"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "system-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "power-state"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "system-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "D",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-globalstatus"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "system-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "E",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-uptime"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "1m",
+      "title": "System Overview",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "Other"
+                },
+                "2": {
+                  "text": "Unknown"
+                },
+                "3": {
+                  "text": "OK"
+                },
+                "4": {
+                  "text": "Non-Critical Fail"
+                },
+                "5": {
+                  "text": "Critical Fail"
+                },
+                "6": {
+                  "text": "Non-Recoverable Fail"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FA6400",
+                "value": null
+              },
+              {
+                "color": "#37872D",
+                "value": 2.9
+              },
+              {
+                "color": "#C4162A",
+                "value": 3.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 19
+      },
+      "id": 444,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"power-state\" FROM \"esxi-01-idrac\" WHERE $timeFilter",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "psu-status"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "PSU Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "Other"
+                },
+                "2": {
+                  "text": "Unknown"
+                },
+                "3": {
+                  "text": "OK"
+                },
+                "4": {
+                  "text": "Non-Critical Fail"
+                },
+                "5": {
+                  "text": "Critical Fail"
+                },
+                "6": {
+                  "text": "Non-Recoverable Fail"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FA6400",
+                "value": null
+              },
+              {
+                "color": "#37872D",
+                "value": 2.9
+              },
+              {
+                "color": "#C4162A",
+                "value": 3.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 4,
+        "y": 19
+      },
+      "id": 9,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "count(sort(idrac_hosts_power_state{idrac_hosts_system_globalstatus=\"\"}))",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-globalstatus"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Global Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 6,
+        "y": 19
+      },
+      "id": 406,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "idrac_hosts_memory_status",
+          "groupBy": [],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"power-state\" FROM \"esxi-01-idrac\" WHERE $timeFilter",
+          "range": true,
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memory-status"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "RAM Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 8,
+        "y": 19
+      },
+      "id": 21,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "bios-version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "BIOS Version",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "Unknown"
+                },
+                "2": {
+                  "text": "Ready"
+                },
+                "3": {
+                  "text": "Failed"
+                },
+                "4": {
+                  "text": "Degraded"
+                },
+                "5": {
+                  "text": "Missing"
+                },
+                "6": {
+                  "text": "Charging"
+                },
+                "7": {
+                  "text": "Below Threshold"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#E0B400",
+                "value": null
+              },
+              {
+                "color": "#37872D",
+                "value": 2
+              },
+              {
+                "color": "#C4162A",
+                "value": 2.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 10,
+        "y": 19
+      },
+      "id": 91,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "raid-batterystate"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "RAID Battery",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 19
+      },
+      "id": 8,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_system_uptime) by (system_servicetag)",
+          "groupBy": [],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"system-servicetag\" FROM /^$idrac_host$/ WHERE (\"system-name\" =~ /^$idrac_host$/) AND $timeFilter",
+          "range": true,
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-servicetag"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Service Tag",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "Other"
+                },
+                "2": {
+                  "text": "Unknown"
+                },
+                "3": {
+                  "text": "Off"
+                },
+                "4": {
+                  "text": "On"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#C4162A",
+                "value": null
+              },
+              {
+                "color": "#FA6400",
+                "value": 2.9
+              },
+              {
+                "color": "#37872D",
+                "value": 3.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 21
+      },
+      "id": 2,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"power-state\" FROM \"esxi-01-idrac\" WHERE $timeFilter",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "power-state"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Power State",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "Other"
+                },
+                "2": {
+                  "text": "Unknown"
+                },
+                "3": {
+                  "text": "OK"
+                },
+                "4": {
+                  "text": "Non-Critical Fail"
+                },
+                "5": {
+                  "text": "Critical Fail"
+                },
+                "6": {
+                  "text": "Non-Recoverable Fail"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FA6400",
+                "value": null
+              },
+              {
+                "color": "#37872D",
+                "value": 2.9
+              },
+              {
+                "color": "#C4162A",
+                "value": 3.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 4,
+        "y": 21
+      },
+      "id": 407,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"power-state\" FROM \"esxi-01-idrac\" WHERE $timeFilter",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "temp-status"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Thermal Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 6,
+        "y": 21
+      },
+      "id": 93,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "/.*/",
+          "values": true
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "idrac_hosts_intrusion_sensor",
+          "groupBy": [],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "intrusion-sensor"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Intrusion",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "Other"
+                },
+                "2": {
+                  "text": "Unknown"
+                },
+                "3": {
+                  "text": "OK"
+                },
+                "4": {
+                  "text": "Non-Critical Fail"
+                },
+                "5": {
+                  "text": "Critical Fail"
+                },
+                "6": {
+                  "text": "Non-Recoverable Fail"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FA6400",
+                "value": null
+              },
+              {
+                "color": "#37872D",
+                "value": 2.9
+              },
+              {
+                "color": "#C4162A",
+                "value": 3.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 0,
+        "y": 22
+      },
+      "id": 405,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+          },
+          "groupBy": [],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"power-state\" FROM \"esxi-01-idrac\" WHERE $timeFilter",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "storage-status"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Storage Status",
+      "type": "stat"
+    },
+    {
+      "columns": [],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fontSize": "90%",
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 2,
+        "y": 23
+      },
+      "id": 649,
+      "links": [],
+      "pluginVersion": "6.7.2",
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:3422",
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "$$hashKey": "object:4195",
+          "alias": "OS Name",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "system-osname",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:4214",
+          "alias": "OS Version",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "system-osversion",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-osname"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-osversion"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "OS Information",
+      "transform": "timeseries_to_rows",
+      "type": "table-old"
+    },
+    {
+      "columns": [],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 8,
+        "y": 23
+      },
+      "id": 298,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:15372",
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "$$hashKey": "object:15373",
+          "alias": "Disk Name",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "disks-name",
+          "preserveFormat": false,
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:15374",
+          "alias": "Status",
+          "align": "left",
+          "colorMode": "cell",
+          "colors": [
+            "#37872D",
+            "#C4162A",
+            "#8F3BB8"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "mappingType": 1,
+          "pattern": "disks-state",
+          "thresholds": [
+            "3.9",
+            "7.9"
+          ],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "$$hashKey": "object:15435",
+              "text": "Unknown",
+              "value": "1"
+            },
+            {
+              "$$hashKey": "object:15436",
+              "text": "Ready",
+              "value": "2"
+            },
+            {
+              "$$hashKey": "object:15437",
+              "text": "Online",
+              "value": "3"
+            },
+            {
+              "$$hashKey": "object:15438",
+              "text": "Foreign",
+              "value": "4"
+            },
+            {
+              "$$hashKey": "object:15439",
+              "text": "Offline",
+              "value": "5"
+            },
+            {
+              "$$hashKey": "object:15440",
+              "text": "Blocked",
+              "value": "6"
+            },
+            {
+              "$$hashKey": "object:15441",
+              "text": "Failed",
+              "value": "7"
+            },
+            {
+              "$$hashKey": "object:15442",
+              "text": "Non-Raid",
+              "value": "8"
+            },
+            {
+              "$$hashKey": "object:15443",
+              "text": "Removed",
+              "value": "9"
+            },
+            {
+              "$$hashKey": "object:15444",
+              "text": "Read-Only",
+              "value": "10"
+            }
+          ]
+        },
+        {
+          "$$hashKey": "object:15375",
+          "alias": "Predictive Fail Alarm",
+          "align": "center",
+          "colorMode": "row",
+          "colors": [
+            "rgba(245, 54, 54, 0)",
+            "#C4162A",
+            "#C4162A"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "disks-predictivefail",
+          "thresholds": [
+            "0.8",
+            "0.9"
+          ],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "$$hashKey": "object:15471",
+              "text": "No",
+              "value": "0"
+            },
+            {
+              "$$hashKey": "object:15472",
+              "text": "YES",
+              "value": "1"
+            }
+          ]
+        },
+        {
+          "$$hashKey": "object:15376",
+          "alias": "Capacity",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "disks-capacity",
+          "thresholds": [],
+          "type": "number",
+          "unit": "decmbytes"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "disks-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "disks-capacity"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "disks-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "disks-state"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "disks-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "disks-predictivefail"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Physical Disk Status",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 14,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 14,
+        "y": 23
+      },
+      "id": 52,
+      "maxPerRow": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "width": -2
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.1.0",
+      "repeat": "idrac_host",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "alias": "Inlet Temp",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_exhaust_temp) by (system_name)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "inlet-temp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 10"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "alias": "Exhaust Temp",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_temp_status) by (system_name)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "exhaust-temp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 10"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_exhaust_temp) by (system_model)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_temp_status) by (system_model)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Air Temp",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "columns": [],
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 26
+      },
+      "id": 332,
+      "links": [],
+      "pageSize": 16,
+      "pluginVersion": "6.6.2",
+      "showHeader": true,
+      "sort": {
+        "col": 2,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:1966",
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "$$hashKey": "object:1967",
+          "alias": "Entry #",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "log-number",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1968",
+          "alias": "Date & Time",
+          "align": "center",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "MM/DD/YY h:mm:ss a",
+          "link": false,
+          "mappingType": 1,
+          "pattern": "log-dates",
+          "thresholds": [],
+          "type": "date",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1969",
+          "alias": "Entry",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "log-entry",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1970",
+          "alias": "Severity",
+          "align": "",
+          "colorMode": "value",
+          "colors": [
+            "#E0B400",
+            "#37872D",
+            "#C4162A"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "log-severity",
+          "thresholds": [
+            "2.9",
+            "3.9"
+          ],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "$$hashKey": "object:2037",
+              "text": "Other",
+              "value": "1"
+            },
+            {
+              "$$hashKey": "object:2038",
+              "text": "Unknown",
+              "value": "2"
+            },
+            {
+              "$$hashKey": "object:2039",
+              "text": "OK",
+              "value": "3"
+            },
+            {
+              "$$hashKey": "object:2040",
+              "text": "Non-Critical",
+              "value": "4"
+            },
+            {
+              "$$hashKey": "object:2041",
+              "text": "Critical",
+              "value": "5"
+            },
+            {
+              "$$hashKey": "object:2042",
+              "text": "Non-Recoverable",
+              "value": "6"
+            }
+          ]
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "log-number"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"log-dates\" FROM \"idrac-hosts\" WHERE (\"system-name\" =~ /^$idrac_host$/) AND $timeFilter GROUP BY \"log-number\" LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "log-dates"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "log-number"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "log-entry"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "log-number"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "log-severity"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "1m",
+      "title": "System Log Entries",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
+      "aliasColors": {
+        "System Watts": "rgb(91, 151, 235)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 6,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 147,
+      "legend": {
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "System Watts",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB_(GRAFANA-01)}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "system-watts"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "warning",
+          "fill": false,
+          "line": true,
+          "op": "gt",
+          "value": 1600,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 1974,
+          "yaxis": "left"
+        }
+      ],
+      "timeRegions": [],
+      "title": "System Watts",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "watt",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "custom": {
+            "fillOpacity": 35,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 720
+              },
+              {
+                "color": "dark-blue",
+                "value": 960
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 14,
+        "y": 29
+      },
+      "id": 70,
+      "options": {
+        "bucketOffset": 0,
+        "combine": false,
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        }
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "alias": "Fan 1",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_fan1_speed) by (system_servicetag)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "fan1-speed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "alias": "Fan 2",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_fan1_speed) by (system_model)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "fan2-speed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "alias": "Fan 3",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_fan1_speed) by (system_name)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "fan3-speed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "alias": "Fan 4",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_fan2_speed) by (system_name)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "fan4-speed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "alias": "Fan 5",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_fan3_speed) by (system_name)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "fan5-speed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "alias": "Fan 6",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_fan4_speed) by (system_name)",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "legendFormat": "__auto",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "range": true,
+          "refId": "F",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "fan6-speed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "editorMode": "code",
+          "expr": "avg(idrac_hosts_fan3_speed) by (system_servicetag)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Fan Speed",
+      "type": "histogram"
+    },
+    {
+      "columns": [],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 6,
+        "y": 30
+      },
+      "id": 564,
+      "showHeader": true,
+      "sort": {
+        "col": 1,
+        "desc": false
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:556",
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "$$hashKey": "object:3334",
+          "alias": "Name",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "nic-name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:3385",
+          "alias": "Vendor",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "nic-vendor",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:3434",
+          "alias": "Status",
+          "align": "auto",
+          "colorMode": "cell",
+          "colors": [
+            "#37872D",
+            "rgba(224, 180, 0, 0)",
+            "#C4162A"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "mappingType": 1,
+          "pattern": "nic-status",
+          "thresholds": [
+            "1.9",
+            "2.1"
+          ],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "$$hashKey": "object:3875",
+              "text": "Connected",
+              "value": "1"
+            },
+            {
+              "$$hashKey": "object:3877",
+              "text": "Disconnected",
+              "value": "2"
+            },
+            {
+              "$$hashKey": "object:3893",
+              "text": "Driver Bad",
+              "value": "3"
+            },
+            {
+              "$$hashKey": "object:3909",
+              "text": "Driver Disabled",
+              "value": "4"
+            },
+            {
+              "$$hashKey": "object:3911",
+              "text": "Initalizing",
+              "value": "10"
+            },
+            {
+              "$$hashKey": "object:3941",
+              "text": "Resetting",
+              "value": "11"
+            },
+            {
+              "$$hashKey": "object:3957",
+              "text": "Closing",
+              "value": "12"
+            },
+            {
+              "$$hashKey": "object:3959",
+              "text": "Not Ready",
+              "value": "13"
+            }
+          ]
+        },
+        {
+          "$$hashKey": "object:3459",
+          "alias": "Current MAC Address",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "mappingType": 1,
+          "pattern": "nic-current_mac",
+          "preserveFormat": false,
+          "sanitize": false,
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "nic-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "nic-vendor"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "nic-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "nic-status"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "nic-name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "idrac-hosts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "nic-current_mac"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "system-name",
+              "operator": "=~",
+              "value": "/^$idrac_host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "1m",
+      "title": "Network Interfaces",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "XbMhi_VVz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 4,
+      "panels": [],
+      "repeat": "idrac_host",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "XbMhi_VVz"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "$idrac_host",
+      "type": "row"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [
+    "idrac",
+    "telegraf",
+    "snmp"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "XbMhi_VVz"
+        },
+        "definition": "SHOW TAG VALUES FROM \"idrac-hosts\" WITH KEY=\"system-name\"",
+        "hide": 0,
+        "includeAll": true,
+        "label": "iDRAC Host",
+        "multi": true,
+        "name": "idrac_host",
+        "options": [],
+        "query": {
+          "query": "SHOW TAG VALUES FROM \"idrac-hosts\" WITH KEY=\"system-name\"",
+          "refId": "Prometheus-idrac_host-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "hidden": false,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "telegraf",
+  "uid": "O19gr0jZk2",
+  "version": 2,
+  "weekStart": ""
+}

--- a/grafana/01-telegraf-dashboard.yaml
+++ b/grafana/01-telegraf-dashboard.yaml
@@ -355,8 +355,8 @@ panels:
     measurement: idrac-hosts
     orderByTime: ASC
     policy: default
-    query: SELECT "bios-version" FROM "idrac-hosts" WHERE ("system-name" =~ /^$idrac_host$/)
-      AND $timeFilter GROUP BY "system-name" LIMIT 1
+    query: max(idrac_hosts_system_globalstatus)
+
     rawQuery: false
     refId: B
     resultFormat: table
@@ -462,7 +462,7 @@ panels:
     mode: discrete
     thresholds:
     - "$$hashKey": object:2501
-      color: "#FF780A"
+      color: "#fe9946"
       tooltip: Other
       value: '1'
     - "$$hashKey": object:2508
@@ -738,8 +738,9 @@ panels:
     measurement: idrac-hosts
     orderByTime: ASC
     policy: default
-    query: SELECT "power-state" FROM "esxi-01-idrac" WHERE $timeFilter
-    rawQuery: false
+    query: count(sort(idrac_hosts_power_state{idrac_hosts_system_globalstatus=""}))
+
+    rawQuery: true
     refId: A
     resultFormat: time_series
     select:

--- a/grafana/01-telegraf-dashboard.yaml
+++ b/grafana/01-telegraf-dashboard.yaml
@@ -1,11 +1,11 @@
 ---
 __inputs:
-- name: DS_INFLUXDB_(GRAFANA-01)
-  label: InfluxDB (grafana-01)
+- name: DS_PROMETHEUS_(GRAFANA-01)
+  label: Prometheus (grafana-01)
   description: ''
   type: datasource
-  pluginId: influxdb
-  pluginName: InfluxDB
+  pluginId: prometheus
+  pluginName: Prometheus
 __elements: []
 __requires:
 - type: panel
@@ -25,8 +25,8 @@ __requires:
   name: Graph (old)
   version: ''
 - type: datasource
-  id: influxdb
-  name: InfluxDB
+  id: prometheus
+  name: Prometheus
   version: 1.0.0
 - type: panel
   id: stat
@@ -51,7 +51,7 @@ annotations:
       tags: []
       type: dashboard
     type: dashboard
-description: SNMP Based Dashboard to Monitor Dell Hosts via iDRAC - by ilovepancakes95
+description: SNMP Telegraf Prometheus Dashboard to Monitor Dell Hosts with iDRAC 
 editable: true
 fiscalYearStartMonth: 0
 graphTooltip: 0
@@ -75,8 +75,8 @@ panels:
     endCountdownTime: '2020-04-10T22:05:00.000Z'
     endText: '00:00:00'
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   dateSettings:
     dateFormat: YYYY-MM-DD
     fontSize: 20px
@@ -151,8 +151,8 @@ panels:
   type: grafana-clock-panel
 - columns: []
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fontSize: 100%
   gridPos:
     h: 6
@@ -486,8 +486,8 @@ panels:
       tooltip: Non-Recoverable Fail
       value: '6'
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   gridPos:
     h: 6
     w: 12
@@ -545,8 +545,8 @@ panels:
     labelTemplate: ''
     usingSplitLabel: false
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -621,8 +621,8 @@ panels:
   title: "$idrac_host"
   type: row
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -681,8 +681,8 @@ panels:
   title: System Uptime
   type: stat
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -753,8 +753,8 @@ panels:
   title: Global Status
   type: stat
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -990,8 +990,8 @@ panels:
   dashLength: 10
   dashes: false
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   decimals: 0
   fieldConfig:
     defaults:
@@ -1122,8 +1122,8 @@ panels:
   yaxis:
     align: false
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -1194,8 +1194,8 @@ panels:
   title: PSU Status
   type: stat
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -1258,8 +1258,8 @@ panels:
   title: CMOS Battery
   type: stat
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -1330,8 +1330,8 @@ panels:
   title: RAID Battery
   type: stat
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -1461,8 +1461,8 @@ panels:
   title: Storage Status
   type: stat
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -1533,8 +1533,8 @@ panels:
   title: RAM Status
   type: stat
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -1605,8 +1605,8 @@ panels:
   title: Thermal Status
   type: stat
 - datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fieldConfig:
     defaults:
       color:
@@ -1672,8 +1672,8 @@ panels:
   type: stat
 - columns: []
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   fontSize: 90%
   gridPos:
     h: 3
@@ -1928,8 +1928,8 @@ panels:
   dashLength: 10
   dashes: false
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
   decimals: 0
   fieldConfig:
     defaults:
@@ -2055,8 +2055,9 @@ panels:
     align: false
 - columns: []
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
+
   fontSize: 100%
   gridPos:
     h: 16
@@ -2238,8 +2239,9 @@ panels:
   dashLength: 10
   dashes: false
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
+
   fieldConfig:
     defaults:
       links: []
@@ -2455,8 +2457,9 @@ panels:
     align: false
 - columns: []
   datasource:
-    type: influxdb
-    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    type: prometheus
+    uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
+
   fontSize: 100%
   gridPos:
     h: 6
@@ -2631,8 +2634,9 @@ templating:
   list:
   - current: {}
     datasource:
-      type: influxdb
-      uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+      type: prometheus
+      uid: "${DS_PROMETHEUS_(GRAFANA-01)}"
+
     definition: SHOW TAG VALUES FROM "idrac-hosts" WITH KEY="system-name"
     hide: 0
     includeAll: true

--- a/grafana/01-telegraf-dashboard.yaml
+++ b/grafana/01-telegraf-dashboard.yaml
@@ -1,0 +1,2672 @@
+---
+__inputs:
+- name: DS_INFLUXDB_(GRAFANA-01)
+  label: InfluxDB (grafana-01)
+  description: ''
+  type: datasource
+  pluginId: influxdb
+  pluginName: InfluxDB
+__elements: []
+__requires:
+- type: panel
+  id: flant-statusmap-panel
+  name: Statusmap
+  version: 0.4.2
+- type: grafana
+  id: grafana
+  name: Grafana
+  version: 8.4.0
+- type: panel
+  id: grafana-clock-panel
+  name: Clock
+  version: 1.3.0
+- type: panel
+  id: graph
+  name: Graph (old)
+  version: ''
+- type: datasource
+  id: influxdb
+  name: InfluxDB
+  version: 1.0.0
+- type: panel
+  id: stat
+  name: Stat
+  version: ''
+- type: panel
+  id: table-old
+  name: Table (old)
+  version: ''
+annotations:
+  list:
+  - "$$hashKey": object:208
+    builtIn: 1
+    datasource: "-- Grafana --"
+    enable: true
+    hide: true
+    iconColor: rgba(0, 211, 255, 1)
+    name: Annotations & Alerts
+    target:
+      limit: 100
+      matchAny: false
+      tags: []
+      type: dashboard
+    type: dashboard
+description: SNMP Based Dashboard to Monitor Dell Hosts via iDRAC - by ilovepancakes95
+editable: true
+fiscalYearStartMonth: 0
+graphTooltip: 0
+id:
+iteration: 1658758215522
+links: []
+liveNow: false
+panels:
+- collapsed: false
+  gridPos:
+    h: 1
+    w: 24
+    x: 0
+    y: 0
+  id: 182
+  panels: []
+  title: iDRAC Summary
+  type: row
+- clockType: 24 hour
+  countdownSettings:
+    endCountdownTime: '2020-04-10T22:05:00.000Z'
+    endText: '00:00:00'
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  dateSettings:
+    dateFormat: YYYY-MM-DD
+    fontSize: 20px
+    fontWeight: normal
+    showDate: false
+  gridPos:
+    h: 3
+    w: 2
+    x: 0
+    y: 1
+  id: 213
+  links: []
+  mode: time
+  options:
+    bgColor: ''
+    clockType: 24 hour
+    countdownSettings:
+      endCountdownTime: '2022-05-16T03:26:04-04:00'
+      endText: '00:00:00'
+    countupSettings:
+      beginCountupTime: '2022-05-16T03:26:04-04:00'
+      beginText: '00:00:00'
+    dateSettings:
+      dateFormat: YYYY-MM-DD
+      fontSize: 20px
+      fontWeight: normal
+      locale: ''
+      showDate: false
+    mode: time
+    refresh: sec
+    timeSettings:
+      fontSize: 12px
+      fontWeight: normal
+    timezone: ''
+    timezoneSettings:
+      fontSize: 12px
+      fontWeight: normal
+      showTimezone: false
+      zoneFormat: offsetAbbv
+  pluginVersion: 1.3.0
+  refreshSettings:
+    syncWithDashboard: false
+  targets:
+  - groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - 'null'
+      type: fill
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - value
+        type: field
+      - params: []
+        type: mean
+    tags: []
+  timeSettings:
+    customFormat: HH:mm:ss
+    fontSize: 32px
+    fontWeight: normal
+  timezoneSettings:
+    fontSize: 12px
+    fontWeight: normal
+    showTimezone: false
+    zoneFormat: offsetAbbv
+  title: Local Time
+  type: grafana-clock-panel
+- columns: []
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fontSize: 100%
+  gridPos:
+    h: 6
+    w: 10
+    x: 2
+    y: 1
+  hideTimeOverride: false
+  id: 119
+  interval: ''
+  pageSize: 25
+  repeatDirection: h
+  showHeader: true
+  sort:
+    col: 1
+    desc: false
+  styles:
+  - "$$hashKey": object:23610
+    alias: ''
+    align: center
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: Time
+    thresholds: []
+    type: hidden
+    unit: short
+  - "$$hashKey": object:23611
+    alias: System Name
+    align: center
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    link: true
+    linkTargetBlank: true
+    linkTooltip: Launch iDRAC Web Interface
+    linkUrl: "${__cell_2:raw}"
+    mappingType: 1
+    pattern: system-name
+    preserveFormat: false
+    thresholds: []
+    type: string
+    unit: short
+  - "$$hashKey": object:23612
+    alias: Service Tag
+    align: center
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: system-servicetag
+    thresholds: []
+    type: string
+    unit: short
+  - "$$hashKey": object:23613
+    alias: Power State
+    align: center
+    colorMode: cell
+    colors:
+    - "#C4162A"
+    - "#FA6400"
+    - "#37872D"
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: power-state
+    thresholds:
+    - '2.9'
+    - '3.9'
+    type: string
+    unit: short
+    valueMaps:
+    - "$$hashKey": object:23697
+      text: Other
+      value: '1'
+    - "$$hashKey": object:23698
+      text: Unknown
+      value: '2'
+    - "$$hashKey": object:23699
+      text: 'Off'
+      value: '3'
+    - "$$hashKey": object:23700
+      text: 'On'
+      value: '4'
+  - "$$hashKey": object:23614
+    alias: Global Status
+    align: center
+    colorMode: cell
+    colors:
+    - "#E0B400"
+    - "#37872D"
+    - "#C4162A"
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: system-globalstatus
+    thresholds:
+    - '2.9'
+    - '3.9'
+    type: string
+    unit: short
+    valueMaps:
+    - "$$hashKey": object:23721
+      text: Other
+      value: '1'
+    - "$$hashKey": object:23722
+      text: Unknown
+      value: '2'
+    - "$$hashKey": object:23723
+      text: Non-Critical Failure
+      value: '4'
+    - "$$hashKey": object:23724
+      text: Critical Failure
+      value: '5'
+    - "$$hashKey": object:23725
+      text: Non-Recoverable Failure
+      value: '6'
+    - "$$hashKey": object:23726
+      text: OK
+      value: '3'
+  - "$$hashKey": object:23615
+    alias: Uptime
+    align: center
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 1
+    mappingType: 1
+    pattern: system-uptime
+    thresholds: []
+    type: number
+    unit: s
+  - "$$hashKey": object:23616
+    alias: System Model
+    align: center
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: system-model
+    preserveFormat: false
+    thresholds: []
+    type: string
+    unit: short
+  - "$$hashKey": object:9602
+    alias: iDRAC URL
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    link: false
+    mappingType: 1
+    pattern: idrac-url
+    thresholds: []
+    type: hidden
+    unit: short
+  targets:
+  - groupBy:
+    - params:
+      - system-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: F
+    resultFormat: table
+    select:
+    - - params:
+        - idrac-url
+        type: field
+    slimit: ''
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - system-name
+      type: tag
+    hide: false
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "bios-version" FROM "idrac-hosts" WHERE ("system-name" =~ /^$idrac_host$/)
+      AND $timeFilter GROUP BY "system-name" LIMIT 1
+    rawQuery: false
+    refId: B
+    resultFormat: table
+    select:
+    - - params:
+        - system-servicetag
+        type: field
+    slimit: ''
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - system-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - system-model
+        type: field
+    slimit: ''
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - system-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: C
+    resultFormat: table
+    select:
+    - - params:
+        - power-state
+        type: field
+    slimit: ''
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - system-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: D
+    resultFormat: table
+    select:
+    - - params:
+        - system-globalstatus
+        type: field
+    slimit: ''
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - system-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: E
+    resultFormat: table
+    select:
+    - - params:
+        - system-uptime
+        type: field
+    slimit: ''
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  timeFrom: 1m
+  title: System Overview
+  transform: table
+  type: table-old
+- cards:
+    cardHSpacing: 10
+    cardMinWidth: 5
+    cardVSpacing: 10
+  color:
+    cardColor: "#b4ff00"
+    colorScale: sqrt
+    colorScheme: interpolateGnYlRd
+    defaultColor: "#757575"
+    exponent: 0.5
+    mode: discrete
+    thresholds:
+    - "$$hashKey": object:2501
+      color: "#FF780A"
+      tooltip: Other
+      value: '1'
+    - "$$hashKey": object:2508
+      color: "#E0B400"
+      tooltip: Unknown
+      value: '2'
+    - "$$hashKey": object:2512
+      color: "#37872D"
+      tooltip: OK
+      value: '3'
+    - "$$hashKey": object:2519
+      color: rgba(224, 47, 68, 0.81)
+      tooltip: Non-Critical Fail
+      value: '4'
+    - "$$hashKey": object:2526
+      color: rgba(196, 22, 42, 0.68)
+      tooltip: Critical Fail
+      value: '5'
+    - "$$hashKey": object:2530
+      color: "#1F60C4"
+      tooltip: Non-Recoverable Fail
+      value: '6'
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  gridPos:
+    h: 6
+    w: 12
+    x: 12
+    y: 1
+  highlightCards: true
+  id: 524
+  interval: ''
+  legend:
+    show: true
+  nullPointMode: as empty
+  pageSize: 15
+  seriesFilterIndex: -1
+  statusmap:
+    ConfigVersion: v1
+  targets:
+  - alias: "[[tag_system-name]]"
+    groupBy:
+    - params:
+      - system-name
+      type: tag
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - system-globalstatus
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: Global Status Map
+  tooltip:
+    extraInfo: ''
+    freezeOnClick: true
+    items: []
+    show: true
+    showExtraInfo: false
+    showItems: false
+  type: flant-statusmap-panel
+  useMax: true
+  usingPagination: false
+  xAxis:
+    show: true
+  yAxis:
+    maxWidth: -1
+    minWidth: -1
+    show: true
+  yAxisSort: metrics
+  yLabel:
+    delimiter: ''
+    labelTemplate: ''
+    usingSplitLabel: false
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          match: 'null'
+          result:
+            text: N/A
+        type: special
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: red
+          value: 80
+      unit: none
+    overrides: []
+  gridPos:
+    h: 3
+    w: 2
+    x: 0
+    y: 4
+  id: 179
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: none
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - 'null'
+      type: fill
+    orderByTime: ASC
+    policy: default
+    query: show tag values cardinality from "idrac-hosts" with key = "system-name"
+    rawQuery: true
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - value
+        type: field
+      - params: []
+        type: mean
+    tags: []
+  title: "# of iDRACs"
+  type: stat
+- collapsed: false
+  gridPos:
+    h: 1
+    w: 24
+    x: 0
+    y: 7
+  id: 4
+  panels: []
+  repeat: idrac_host
+  title: "$idrac_host"
+  type: row
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      decimals: 1
+      mappings:
+      - options:
+          match: 'null'
+          result:
+            text: N/A
+        type: special
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: red
+          value: 80
+      unit: s
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 0
+    y: 8
+  id: 6
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: none
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - system-uptime
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: System Uptime
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: Other
+          '2':
+            text: Unknown
+          '3':
+            text: OK
+          '4':
+            text: Non-Critical Fail
+          '5':
+            text: Critical Fail
+          '6':
+            text: Non-Recoverable Fail
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#FA6400"
+          value:
+        - color: "#37872D"
+          value: 2.9
+        - color: "#C4162A"
+          value: 3.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 2
+    y: 8
+  id: 9
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: background
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "power-state" FROM "esxi-01-idrac" WHERE $timeFilter
+    rawQuery: false
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - system-globalstatus
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: Global Status
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: Other
+          '2':
+            text: Unknown
+          '3':
+            text: 'Off'
+          '4':
+            text: 'On'
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#C4162A"
+          value:
+        - color: "#FA6400"
+          value: 2.9
+        - color: "#37872D"
+          value: 3.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 4
+    y: 8
+  id: 2
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: background
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "power-state" FROM "esxi-01-idrac" WHERE $timeFilter
+    rawQuery: false
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - power-state
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: Power State
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          match: 'null'
+          result:
+            text: N/A
+        type: special
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: red
+          value: 80
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 6
+    y: 8
+  id: 8
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: none
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "system-servicetag" FROM /^$idrac_host$/ WHERE ("system-name" =~
+      /^$idrac_host$/) AND $timeFilter
+    rawQuery: false
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - system-servicetag
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: Service Tag
+  type: stat
+- aliasColors:
+    System Watts: rgb(91, 151, 235)
+  bars: false
+  dashLength: 10
+  dashes: false
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      links: []
+    overrides: []
+  fill: 1
+  fillGradient: 0
+  gridPos:
+    h: 6
+    w: 8
+    x: 8
+    y: 8
+  hiddenSeries: false
+  id: 147
+  legend:
+    avg: false
+    current: true
+    max: true
+    min: true
+    show: true
+    total: false
+    values: true
+  lines: true
+  linewidth: 1
+  links: []
+  nullPointMode: 'null'
+  options:
+    alertThreshold: true
+  percentage: false
+  pluginVersion: 8.4.0
+  pointradius: 2
+  points: false
+  renderer: flot
+  seriesOverrides: []
+  spaceLength: 10
+  stack: false
+  steppedLine: false
+  targets:
+  - alias: System Watts
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - system-watts
+        type: field
+      - params: []
+        type: mean
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  thresholds:
+  - colorMode: warning
+    fill: false
+    line: true
+    op: gt
+    value: 1600
+    yaxis: left
+  - colorMode: critical
+    fill: true
+    line: true
+    op: gt
+    value: 1974
+    yaxis: left
+  timeRegions: []
+  title: System Watts
+  tooltip:
+    shared: true
+    sort: 0
+    value_type: individual
+  type: graph
+  xaxis:
+    mode: time
+    show: true
+    values: []
+  yaxes:
+  - format: watt
+    logBase: 1
+    show: true
+  - format: short
+    logBase: 1
+    show: true
+  yaxis:
+    align: false
+- aliasColors:
+    CPU 1 Temp: rgb(91, 151, 235)
+    CPU 2 Temp: rgb(90, 161, 80)
+  bars: false
+  dashLength: 10
+  dashes: false
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  decimals: 0
+  fieldConfig:
+    defaults:
+      links: []
+    overrides: []
+  fill: 1
+  fillGradient: 0
+  gridPos:
+    h: 7
+    w: 8
+    x: 16
+    y: 8
+  hiddenSeries: false
+  id: 35
+  legend:
+    avg: true
+    current: true
+    max: true
+    min: false
+    show: true
+    total: false
+    values: true
+  lines: true
+  linewidth: 1
+  nullPointMode: 'null'
+  options:
+    alertThreshold: true
+  percentage: false
+  pluginVersion: 8.4.0
+  pointradius: 2
+  points: false
+  renderer: flot
+  seriesOverrides:
+  - alias: CPU 1 Temp
+    yaxis: 1
+  - alias: CPU 2 Temp
+    yaxis: 1
+  spaceLength: 10
+  stack: false
+  steppedLine: false
+  targets:
+  - alias: CPU 1 Temp
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - cpu1-temp
+        type: field
+      - params: []
+        type: mean
+      - params:
+        - " / 10"
+        type: math
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - alias: CPU 2 Temp
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: B
+    resultFormat: time_series
+    select:
+    - - params:
+        - cpu2-temp
+        type: field
+      - params: []
+        type: mean
+      - params:
+        - " / 10"
+        type: math
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  thresholds:
+  - colorMode: warning
+    fill: false
+    line: true
+    op: gt
+    value: 70
+    yaxis: left
+  - colorMode: critical
+    fill: true
+    fillColor: rgba(50, 116, 217, 0.2)
+    line: true
+    lineColor: rgba(31, 96, 196, 0.6)
+    op: gt
+    value: 84
+    yaxis: left
+  timeRegions: []
+  title: CPU Temp
+  tooltip:
+    shared: true
+    sort: 0
+    value_type: individual
+  type: graph
+  xaxis:
+    mode: time
+    show: true
+    values: []
+  yaxes:
+  - decimals: 0
+    format: celsius
+    logBase: 1
+    show: true
+  - format: short
+    logBase: 1
+    show: true
+  yaxis:
+    align: false
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: Other
+          '2':
+            text: Unknown
+          '3':
+            text: OK
+          '4':
+            text: Non-Critical Fail
+          '5':
+            text: Critical Fail
+          '6':
+            text: Non-Recoverable Fail
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#FA6400"
+          value:
+        - color: "#37872D"
+          value: 2.9
+        - color: "#C4162A"
+          value: 3.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 0
+    y: 10
+  id: 444
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: background
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "power-state" FROM "esxi-01-idrac" WHERE $timeFilter
+    rawQuery: false
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - psu-status
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: PSU Status
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: Predictive Fail
+          '2':
+            text: Failed
+          '4':
+            text: OK
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#E0B400"
+          value:
+        - color: "#C4162A"
+          value: 1.9
+        - color: "#37872D"
+          value: 3.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 2
+    y: 10
+  id: 90
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: background
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - cmos-batterystate
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: CMOS Battery
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: Unknown
+          '2':
+            text: Ready
+          '3':
+            text: Failed
+          '4':
+            text: Degraded
+          '5':
+            text: Missing
+          '6':
+            text: Charging
+          '7':
+            text: Below Threshold
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#E0B400"
+          value:
+        - color: "#37872D"
+          value: 2
+        - color: "#C4162A"
+          value: 2.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 4
+    y: 10
+  id: 91
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: background
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - raid-batterystate
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: RAID Battery
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          match: 'null'
+          result:
+            text: N/A
+        type: special
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: red
+          value: 80
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 6
+    y: 10
+  id: 21
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: none
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - bios-version
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: BIOS Version
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: Other
+          '2':
+            text: Unknown
+          '3':
+            text: OK
+          '4':
+            text: Non-Critical Fail
+          '5':
+            text: Critical Fail
+          '6':
+            text: Non-Recoverable Fail
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#FA6400"
+          value:
+        - color: "#37872D"
+          value: 2.9
+        - color: "#C4162A"
+          value: 3.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 0
+    y: 12
+  id: 405
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: background
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "power-state" FROM "esxi-01-idrac" WHERE $timeFilter
+    rawQuery: false
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - storage-status
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: Storage Status
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: Other
+          '2':
+            text: Unknown
+          '3':
+            text: OK
+          '4':
+            text: Non-Critical Fail
+          '5':
+            text: Critical Fail
+          '6':
+            text: Non-Recoverable Fail
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#FA6400"
+          value:
+        - color: "#37872D"
+          value: 2.9
+        - color: "#C4162A"
+          value: 3.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 2
+    y: 12
+  id: 406
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: background
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "power-state" FROM "esxi-01-idrac" WHERE $timeFilter
+    rawQuery: false
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - memory-status
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: RAM Status
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: Other
+          '2':
+            text: Unknown
+          '3':
+            text: OK
+          '4':
+            text: Non-Critical Fail
+          '5':
+            text: Critical Fail
+          '6':
+            text: Non-Recoverable Fail
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#FA6400"
+          value:
+        - color: "#37872D"
+          value: 2.9
+        - color: "#C4162A"
+          value: 3.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 4
+    y: 12
+  id: 407
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: background
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "power-state" FROM "esxi-01-idrac" WHERE $timeFilter
+    rawQuery: false
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - temp-status
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: Thermal Status
+  type: stat
+- datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings:
+      - options:
+          '1':
+            text: No Breach
+          '2':
+            text: Current Breach
+          '3':
+            text: Prior Breach
+          '4':
+            text: Sensor Fail
+        type: value
+      thresholds:
+        mode: absolute
+        steps:
+        - color: "#299c46"
+          value:
+        - color: "#C4162A"
+          value: 1.9
+        - color: "#E0B400"
+          value: 3.9
+      unit: none
+    overrides: []
+  gridPos:
+    h: 2
+    w: 2
+    x: 6
+    y: 12
+  id: 93
+  links: []
+  maxDataPoints: 100
+  options:
+    colorMode: value
+    graphMode: none
+    justifyMode: auto
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    textMode: auto
+  pluginVersion: 8.4.0
+  targets:
+  - groupBy: []
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - intrusion-sensor
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: Intrusion
+  type: stat
+- columns: []
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fontSize: 90%
+  gridPos:
+    h: 3
+    w: 7
+    x: 0
+    y: 14
+  id: 649
+  links: []
+  pluginVersion: 6.7.2
+  showHeader: true
+  sort:
+    col: 0
+    desc: true
+  styles:
+  - "$$hashKey": object:3422
+    alias: Time
+    align: auto
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    pattern: Time
+    type: hidden
+  - "$$hashKey": object:4195
+    alias: OS Name
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: system-osname
+    thresholds: []
+    type: string
+    unit: short
+  - "$$hashKey": object:4214
+    alias: OS Version
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: system-osversion
+    thresholds: []
+    type: string
+    unit: short
+  targets:
+  - groupBy: []
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - system-osname
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy: []
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: B
+    resultFormat: table
+    select:
+    - - params:
+        - system-osversion
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: OS Information
+  transform: timeseries_to_rows
+  type: table-old
+- columns: []
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fontSize: 100%
+  gridPos:
+    h: 19
+    w: 9
+    x: 7
+    y: 14
+  id: 332
+  links: []
+  pageSize: 16
+  pluginVersion: 6.6.2
+  showHeader: true
+  sort:
+    col: 2
+    desc: true
+  styles:
+  - "$$hashKey": object:1966
+    alias: Time
+    align: auto
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    pattern: Time
+    type: hidden
+  - "$$hashKey": object:1967
+    alias: 'Entry #'
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 0
+    mappingType: 1
+    pattern: log-number
+    thresholds: []
+    type: hidden
+    unit: short
+  - "$$hashKey": object:1968
+    alias: Date & Time
+    align: center
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: MM/DD/YY h:mm:ss a
+    link: false
+    mappingType: 1
+    pattern: log-dates
+    thresholds: []
+    type: date
+    unit: short
+  - "$$hashKey": object:1969
+    alias: Entry
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: log-entry
+    thresholds: []
+    type: string
+    unit: short
+  - "$$hashKey": object:1970
+    alias: Severity
+    align: ''
+    colorMode: value
+    colors:
+    - "#E0B400"
+    - "#37872D"
+    - "#C4162A"
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 0
+    mappingType: 1
+    pattern: log-severity
+    thresholds:
+    - '2.9'
+    - '3.9'
+    type: string
+    unit: short
+    valueMaps:
+    - "$$hashKey": object:2037
+      text: Other
+      value: '1'
+    - "$$hashKey": object:2038
+      text: Unknown
+      value: '2'
+    - "$$hashKey": object:2039
+      text: OK
+      value: '3'
+    - "$$hashKey": object:2040
+      text: Non-Critical
+      value: '4'
+    - "$$hashKey": object:2041
+      text: Critical
+      value: '5'
+    - "$$hashKey": object:2042
+      text: Non-Recoverable
+      value: '6'
+  targets:
+  - groupBy:
+    - params:
+      - log-number
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    query: SELECT "log-dates" FROM "idrac-hosts" WHERE ("system-name" =~ /^$idrac_host$/)
+      AND $timeFilter GROUP BY "log-number" LIMIT 1
+    rawQuery: false
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - log-dates
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - log-number
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: B
+    resultFormat: table
+    select:
+    - - params:
+        - log-entry
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - log-number
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: C
+    resultFormat: table
+    select:
+    - - params:
+        - log-severity
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  timeFrom: 1m
+  title: System Log Entries
+  transform: table
+  type: table-old
+- aliasColors:
+    Exhaust Temp: rgb(90, 161, 80)
+    Inlet Temp: rgb(91, 151, 235)
+  bars: false
+  dashLength: 10
+  dashes: false
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  decimals: 0
+  fieldConfig:
+    defaults:
+      links: []
+    overrides: []
+  fill: 1
+  fillGradient: 0
+  gridPos:
+    h: 6
+    w: 8
+    x: 16
+    y: 15
+  hiddenSeries: false
+  id: 52
+  legend:
+    avg: true
+    current: true
+    max: true
+    min: false
+    show: true
+    total: false
+    values: true
+  lines: true
+  linewidth: 1
+  nullPointMode: 'null'
+  options:
+    alertThreshold: true
+  percentage: false
+  pluginVersion: 8.4.0
+  pointradius: 2
+  points: false
+  renderer: flot
+  seriesOverrides: []
+  spaceLength: 10
+  stack: false
+  steppedLine: false
+  targets:
+  - alias: Inlet Temp
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - inlet-temp
+        type: field
+      - params: []
+        type: mean
+      - params:
+        - " / 10"
+        type: math
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - alias: Exhaust Temp
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: B
+    resultFormat: time_series
+    select:
+    - - params:
+        - exhaust-temp
+        type: field
+      - params: []
+        type: mean
+      - params:
+        - " / 10"
+        type: math
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  thresholds:
+  - colorMode: warning
+    fill: false
+    line: true
+    op: gt
+    value: 42
+    yaxis: left
+  - colorMode: critical
+    fill: true
+    line: true
+    op: gt
+    value: 47
+    yaxis: left
+  timeRegions: []
+  title: Air Temp
+  tooltip:
+    shared: true
+    sort: 0
+    value_type: individual
+  type: graph
+  xaxis:
+    mode: time
+    show: true
+    values: []
+  yaxes:
+  - decimals: 0
+    format: celsius
+    logBase: 1
+    show: true
+  - format: short
+    logBase: 1
+    show: true
+  yaxis:
+    align: false
+- columns: []
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fontSize: 100%
+  gridPos:
+    h: 16
+    w: 7
+    x: 0
+    y: 17
+  id: 298
+  showHeader: true
+  sort:
+    col: 0
+    desc: true
+  styles:
+  - "$$hashKey": object:15372
+    alias: Time
+    align: auto
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    pattern: Time
+    type: hidden
+  - "$$hashKey": object:15373
+    alias: Disk Name
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: disks-name
+    preserveFormat: false
+    thresholds: []
+    type: string
+    unit: short
+  - "$$hashKey": object:15374
+    alias: Status
+    align: left
+    colorMode: cell
+    colors:
+    - "#37872D"
+    - "#C4162A"
+    - "#8F3BB8"
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    mappingType: 1
+    pattern: disks-state
+    thresholds:
+    - '3.9'
+    - '7.9'
+    type: string
+    unit: short
+    valueMaps:
+    - "$$hashKey": object:15435
+      text: Unknown
+      value: '1'
+    - "$$hashKey": object:15436
+      text: Ready
+      value: '2'
+    - "$$hashKey": object:15437
+      text: Online
+      value: '3'
+    - "$$hashKey": object:15438
+      text: Foreign
+      value: '4'
+    - "$$hashKey": object:15439
+      text: Offline
+      value: '5'
+    - "$$hashKey": object:15440
+      text: Blocked
+      value: '6'
+    - "$$hashKey": object:15441
+      text: Failed
+      value: '7'
+    - "$$hashKey": object:15442
+      text: Non-Raid
+      value: '8'
+    - "$$hashKey": object:15443
+      text: Removed
+      value: '9'
+    - "$$hashKey": object:15444
+      text: Read-Only
+      value: '10'
+  - "$$hashKey": object:15375
+    alias: Predictive Fail Alarm
+    align: center
+    colorMode: row
+    colors:
+    - rgba(245, 54, 54, 0)
+    - "#C4162A"
+    - "#C4162A"
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: disks-predictivefail
+    thresholds:
+    - '0.8'
+    - '0.9'
+    type: string
+    unit: short
+    valueMaps:
+    - "$$hashKey": object:15471
+      text: 'No'
+      value: '0'
+    - "$$hashKey": object:15472
+      text: 'YES'
+      value: '1'
+  - "$$hashKey": object:15376
+    alias: Capacity
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 0
+    mappingType: 1
+    pattern: disks-capacity
+    thresholds: []
+    type: number
+    unit: decmbytes
+  targets:
+  - groupBy:
+    - params:
+      - disks-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: C
+    resultFormat: table
+    select:
+    - - params:
+        - disks-capacity
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - disks-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - disks-state
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - disks-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: B
+    resultFormat: table
+    select:
+    - - params:
+        - disks-predictivefail
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  title: Physical Disk Status
+  transform: table
+  type: table-old
+- aliasColors: {}
+  bars: false
+  dashLength: 10
+  dashes: false
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fieldConfig:
+    defaults:
+      links: []
+    overrides: []
+  fill: 0
+  fillGradient: 0
+  gridPos:
+    h: 6
+    w: 8
+    x: 16
+    y: 21
+  hiddenSeries: false
+  id: 70
+  legend:
+    avg: false
+    current: false
+    max: false
+    min: false
+    show: true
+    total: false
+    values: false
+  lines: true
+  linewidth: 1
+  nullPointMode: 'null'
+  options:
+    alertThreshold: true
+  percentage: false
+  pluginVersion: 8.4.0
+  pointradius: 2
+  points: false
+  renderer: flot
+  seriesOverrides: []
+  spaceLength: 10
+  stack: false
+  steppedLine: false
+  targets:
+  - alias: Fan 1
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: time_series
+    select:
+    - - params:
+        - fan1-speed
+        type: field
+      - params: []
+        type: mean
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - alias: Fan 2
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: B
+    resultFormat: time_series
+    select:
+    - - params:
+        - fan2-speed
+        type: field
+      - params: []
+        type: mean
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - alias: Fan 3
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: C
+    resultFormat: time_series
+    select:
+    - - params:
+        - fan3-speed
+        type: field
+      - params: []
+        type: mean
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - alias: Fan 4
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: D
+    resultFormat: time_series
+    select:
+    - - params:
+        - fan4-speed
+        type: field
+      - params: []
+        type: mean
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - alias: Fan 5
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: E
+    resultFormat: time_series
+    select:
+    - - params:
+        - fan5-speed
+        type: field
+      - params: []
+        type: mean
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - alias: Fan 6
+    groupBy:
+    - params:
+      - "$__interval"
+      type: time
+    - params:
+      - none
+      type: fill
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: F
+    resultFormat: time_series
+    select:
+    - - params:
+        - fan6-speed
+        type: field
+      - params: []
+        type: mean
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  thresholds:
+  - "$$hashKey": object:1180
+    colorMode: warning
+    fill: false
+    line: true
+    op: lt
+    value: 960
+    yaxis: left
+  - "$$hashKey": object:1181
+    colorMode: critical
+    fill: true
+    line: true
+    op: lt
+    value: 720
+    yaxis: left
+  timeRegions: []
+  title: Fan Speed
+  tooltip:
+    shared: true
+    sort: 0
+    value_type: individual
+  type: graph
+  xaxis:
+    mode: time
+    show: true
+    values: []
+  yaxes:
+  - "$$hashKey": object:1152
+    decimals: 0
+    format: none
+    label: RPM
+    logBase: 1
+    show: true
+  - "$$hashKey": object:1153
+    format: short
+    logBase: 1
+    show: true
+  yaxis:
+    align: false
+- columns: []
+  datasource:
+    type: influxdb
+    uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+  fontSize: 100%
+  gridPos:
+    h: 6
+    w: 8
+    x: 16
+    y: 27
+  id: 564
+  showHeader: true
+  sort:
+    col: 1
+    desc: false
+  styles:
+  - "$$hashKey": object:556
+    alias: Time
+    align: auto
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    pattern: Time
+    type: hidden
+  - "$$hashKey": object:3334
+    alias: Name
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: nic-name
+    thresholds: []
+    type: string
+    unit: short
+  - "$$hashKey": object:3385
+    alias: Vendor
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    mappingType: 1
+    pattern: nic-vendor
+    thresholds: []
+    type: string
+    unit: short
+  - "$$hashKey": object:3434
+    alias: Status
+    align: auto
+    colorMode: cell
+    colors:
+    - "#37872D"
+    - rgba(224, 180, 0, 0)
+    - "#C4162A"
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    mappingType: 1
+    pattern: nic-status
+    thresholds:
+    - '1.9'
+    - '2.1'
+    type: string
+    unit: short
+    valueMaps:
+    - "$$hashKey": object:3875
+      text: Connected
+      value: '1'
+    - "$$hashKey": object:3877
+      text: Disconnected
+      value: '2'
+    - "$$hashKey": object:3893
+      text: Driver Bad
+      value: '3'
+    - "$$hashKey": object:3909
+      text: Driver Disabled
+      value: '4'
+    - "$$hashKey": object:3911
+      text: Initalizing
+      value: '10'
+    - "$$hashKey": object:3941
+      text: Resetting
+      value: '11'
+    - "$$hashKey": object:3957
+      text: Closing
+      value: '12'
+    - "$$hashKey": object:3959
+      text: Not Ready
+      value: '13'
+  - "$$hashKey": object:3459
+    alias: Current MAC Address
+    align: auto
+    colors:
+    - rgba(245, 54, 54, 0.9)
+    - rgba(237, 129, 40, 0.89)
+    - rgba(50, 172, 45, 0.97)
+    dateFormat: YYYY-MM-DD HH:mm:ss
+    decimals: 2
+    link: false
+    mappingType: 1
+    pattern: nic-current_mac
+    preserveFormat: false
+    sanitize: false
+    thresholds: []
+    type: string
+    unit: short
+  targets:
+  - groupBy:
+    - params:
+      - nic-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: A
+    resultFormat: table
+    select:
+    - - params:
+        - nic-vendor
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - nic-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: B
+    resultFormat: table
+    select:
+    - - params:
+        - nic-status
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  - groupBy:
+    - params:
+      - nic-name
+      type: tag
+    limit: '1'
+    measurement: idrac-hosts
+    orderByTime: ASC
+    policy: default
+    refId: C
+    resultFormat: table
+    select:
+    - - params:
+        - nic-current_mac
+        type: field
+    tags:
+    - key: system-name
+      operator: "=~"
+      value: "/^$idrac_host$/"
+  timeFrom: 1m
+  title: Network Interfaces
+  transform: table
+  type: table-old
+refresh: 10s
+schemaVersion: 35
+style: dark
+tags:
+- idrac
+- telegraf
+- snmp
+templating:
+  list:
+  - current: {}
+    datasource:
+      type: influxdb
+      uid: "${DS_INFLUXDB_(GRAFANA-01)}"
+    definition: SHOW TAG VALUES FROM "idrac-hosts" WITH KEY="system-name"
+    hide: 0
+    includeAll: true
+    label: iDRAC Host
+    multi: true
+    name: idrac_host
+    options: []
+    query: SHOW TAG VALUES FROM "idrac-hosts" WITH KEY="system-name"
+    refresh: 2
+    regex: ''
+    skipUrlSync: false
+    sort: 1
+    tagValuesQuery: ''
+    tagsQuery: ''
+    type: query
+    useTags: false
+time:
+  from: now-3h
+  to: now
+timepicker:
+  hidden: false
+  refresh_intervals:
+  - 5s
+  - 10s
+  - 30s
+  - 1m
+  - 5m
+  - 15m
+  - 30m
+  - 1h
+  - 2h
+  - 1d
+timezone: ''
+title: iDRAC - Host Stats
+uid: O19gr0jZk
+version: 131
+weekStart: ''

--- a/grafana/co2.yaml
+++ b/grafana/co2.yaml
@@ -1,0 +1,679 @@
+---
+annotations:
+  list:
+  - builtIn: 1
+    datasource:
+      type: datasource
+      uid: grafana
+    enable: true
+    hide: true
+    iconColor: rgba(0, 211, 255, 1)
+    name: Annotations & Alerts
+    target:
+      limit: 100
+      matchAny: false
+      tags: []
+      type: dashboard
+    type: dashboard
+description: Dashboard for Kepler Exporter
+editable: true
+fiscalYearStartMonth: 0
+graphTooltip: 0
+id: 3
+links: []
+liveNow: false
+panels:
+- collapsed: false
+  datasource:
+    type: prometheus
+    uid: 7tfubjI4k
+  gridPos:
+    h: 1
+    w: 24
+    x: 0
+    y: 0
+  id: 11
+  panels: []
+  targets:
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    refId: A
+  title: Carbon Emissions
+  type: row
+- datasource:
+    type: prometheus
+    uid: 7tfubjI4k
+  fieldConfig:
+    defaults:
+      color:
+        mode: palette-classic
+      custom:
+        axisCenteredZero: false
+        axisColorMode: series
+        axisGridShow: true
+        axisLabel: ''
+        axisPlacement: auto
+        barAlignment: 0
+        drawStyle: line
+        fillOpacity: 16
+        gradientMode: opacity
+        hideFrom:
+          legend: false
+          tooltip: false
+          viz: false
+        lineInterpolation: linear
+        lineStyle:
+          fill: solid
+        lineWidth: 1
+        pointSize: 5
+        scaleDistribution:
+          type: linear
+        showPoints: auto
+        spanNulls: false
+        stacking:
+          group: A
+          mode: normal
+        thresholdsStyle:
+          mode: 'off'
+      mappings: []
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: red
+          value: 80
+    overrides:
+    - __systemRef: hideSeriesFrom
+      matcher:
+        id: byNames
+        options:
+          mode: exclude
+          names:
+          - "delta(sum(pod_curr_energy_millijoule{pod_namespace='system'})[10m:])\n\n"
+          prefix: 'All except:'
+          readOnly: true
+      properties:
+      - id: custom.hideFrom
+        value:
+          legend: false
+          tooltip: false
+          viz: true
+  gridPos:
+    h: 13
+    w: 21
+    x: 0
+    y: 1
+  id: 14
+  options:
+    legend:
+      calcs: []
+      displayMode: list
+      placement: bottom
+      showLegend: true
+    tooltip:
+      mode: multi
+      sort: asc
+  pluginVersion: 9.1.0
+  targets:
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    expr: "delta(sum(pod_curr_energy_millijoule{pod_namespace='$namespace'})[10m:])\n\n"
+    legendFormat: __auto
+    range: true
+    refId: A
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    expr: "predict_linear(sum(pod_curr_energy_millijoule{pod_namespace='$namespace'})[4h:],
+      3600)\n\n"
+    hide: false
+    legendFormat: __auto
+    range: true
+    refId: B
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    expr: "sum by (pod_namespace) (sum_over_time(pod_curr_energy_in_pkg_millijoule[24h])*15/3/3600000000)\n\n"
+    hide: false
+    legendFormat: __auto
+    range: true
+    refId: C
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    expr: "deriv(sum(pod_curr_energy_millijoule{pod_node_name='$pod',pod_namespace='$namespace'})[10m:])\n\n"
+    hide: false
+    legendFormat: __auto
+    range: true
+    refId: D
+  title: Kepler Tests
+  type: timeseries
+- datasource:
+    type: prometheus
+    uid: 7tfubjI4k
+  description: Using CO2 emissions  by power generation type as reported by US Energy
+    Information Administration https://www.eia.gov/tools/faqs/faq.php?id=74&t=11
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings: []
+      thresholds:
+        mode: percentage
+        steps:
+        - color: green
+          value:
+        - color: "#EAB839"
+          value: 60
+        - color: red
+          value: 80
+    overrides: []
+  gridPos:
+    h: 11
+    w: 21
+    x: 0
+    y: 14
+  id: 12
+  options:
+    displayMode: lcd
+    minVizHeight: 10
+    minVizWidth: 0
+    orientation: horizontal
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    showUnfilled: true
+  pluginVersion: 9.1.0
+  targets:
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    exemplar: true
+    expr: "sum(rate(pod_curr_energy_millijoule{pod_namespace='$namespace'}[24h])/(20*60*24)/3600000000*$coal)\n "
+    instant: false
+    interval: ''
+    legendFormat: CO2 Coal
+    refId: A
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    exemplar: true
+    expr: sum(rate(pod_curr_energy_millijoule{pod_namespace='$namespace'}[24h])/(20*60*24)/3600000000*$petroleum)
+    hide: false
+    interval: ''
+    legendFormat: CO2 Petroleum
+    range: true
+    refId: B
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    exemplar: true
+    expr: sum(rate(pod_curr_energy_millijoule{pod_namespace='$namespace'}[24h])/(20*60*24)/3600000000*$natural_gas)
+    hide: false
+    interval: ''
+    legendFormat: CO2 Natural Gas
+    range: true
+    refId: C
+  title: Namespace Carbon Footprint (pounds per kWh in 24hrs)
+  transparent: true
+  type: bargauge
+- collapsed: false
+  datasource:
+    type: prometheus
+    uid: 7tfubjI4k
+  gridPos:
+    h: 1
+    w: 24
+    x: 0
+    y: 25
+  id: 8
+  panels: []
+  targets:
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    refId: A
+  title: Energy Consumption
+  type: row
+- datasource:
+    type: prometheus
+    uid: 7tfubjI4k
+  description: The mW per minute
+  fieldConfig:
+    defaults:
+      color:
+        mode: palette-classic
+      custom:
+        axisCenteredZero: false
+        axisColorMode: text
+        axisLabel: ''
+        axisPlacement: auto
+        barAlignment: 0
+        drawStyle: line
+        fillOpacity: 0
+        gradientMode: none
+        hideFrom:
+          graph: false
+          legend: false
+          tooltip: false
+          viz: false
+        lineInterpolation: linear
+        lineWidth: 1
+        pointSize: 5
+        scaleDistribution:
+          type: linear
+        showPoints: auto
+        spanNulls: false
+        stacking:
+          group: A
+          mode: none
+        thresholdsStyle:
+          mode: 'off'
+      mappings: []
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: red
+          value: 80
+    overrides: []
+  gridPos:
+    h: 9
+    w: 12
+    x: 0
+    y: 26
+  id: 2
+  options:
+    legend:
+      calcs: []
+      displayMode: list
+      placement: bottom
+      showLegend: true
+    tooltip:
+      mode: single
+      sort: none
+  targets:
+  - datasource:
+      type: prometheus
+      uid: "${DS_PROMETHEUS}"
+    editorMode: code
+    exemplar: true
+    expr: rate(pod_curr_energy_millijoule{pod_namespace="$namespace", pod_name="$pod"}[1m])/20
+    interval: ''
+    legendFormat: Total
+    range: true
+    refId: A
+  - datasource:
+      type: prometheus
+      uid: "${DS_PROMETHEUS}"
+    editorMode: code
+    exemplar: true
+    expr: rate(pod_curr_energy_millijoule{pod_namespace="$namespace", pod_name="$pod"}[1m])/20
+    hide: false
+    interval: ''
+    legendFormat: CPU
+    range: true
+    refId: B
+  - datasource:
+      type: prometheus
+      uid: "${DS_PROMETHEUS}"
+    exemplar: true
+    expr: rate(pod_dram_energy_current{pod_namespace="$namespace", pod_name="$pod"}[1m])/20
+    hide: false
+    interval: ''
+    legendFormat: DRAM
+    refId: C
+  title: Pod Current Energy Consumption (mW)
+  type: timeseries
+- datasource:
+    type: prometheus
+    uid: 7tfubjI4k
+  description: Total kW Consumed
+  fieldConfig:
+    defaults:
+      color:
+        mode: palette-classic
+      custom:
+        axisCenteredZero: false
+        axisColorMode: text
+        axisLabel: ''
+        axisPlacement: auto
+        barAlignment: 0
+        drawStyle: line
+        fillOpacity: 0
+        gradientMode: none
+        hideFrom:
+          graph: false
+          legend: false
+          tooltip: false
+          viz: false
+        lineInterpolation: linear
+        lineWidth: 1
+        pointSize: 5
+        scaleDistribution:
+          type: linear
+        showPoints: auto
+        spanNulls: false
+        stacking:
+          group: A
+          mode: none
+        thresholdsStyle:
+          mode: 'off'
+      mappings: []
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: red
+          value: 80
+    overrides:
+    - __systemRef: hideSeriesFrom
+      matcher:
+        id: byNames
+        options:
+          mode: exclude
+          names:
+          - '{pod_namespace="newton-odh"}'
+          prefix: 'All except:'
+          readOnly: true
+      properties:
+      - id: custom.hideFrom
+        value:
+          legend: false
+          tooltip: false
+          viz: true
+  gridPos:
+    h: 9
+    w: 12
+    x: 12
+    y: 26
+  id: 3
+  options:
+    legend:
+      calcs: []
+      displayMode: list
+      placement: bottom
+      showLegend: true
+    tooltip:
+      mode: single
+      sort: none
+  pluginVersion: 7.5.15
+  targets:
+  - datasource:
+      type: prometheus
+      uid: "${DS_PROMETHEUS}"
+    editorMode: code
+    exemplar: true
+    expr: rate(pod_curr_energy_millijoule{pod_namespace="$namespace", pod_name="$pod"}[24h])/(20*60*24)/3600000000
+    instant: false
+    interval: ''
+    legendFormat: TOTAL {{pod_name}}
+    refId: A
+  - datasource:
+      type: prometheus
+      uid: "${DS_PROMETHEUS}"
+    editorMode: code
+    exemplar: true
+    expr: rate(pod_curr_energy_millijoule{pod_namespace="$namespace", pod_name="$pod"}[24h])/(20*60*24)/3600000000
+    hide: false
+    instant: false
+    interval: ''
+    legendFormat: CPU {{pod_name}}
+    refId: B
+  - datasource:
+      type: prometheus
+      uid: "${DS_PROMETHEUS}"
+    editorMode: code
+    exemplar: true
+    expr: rate(pod_curr_energy_millijoule{pod_namespace="$namespace", pod_name="$pod"}[24h])/(20*60*24)/3600000000
+    hide: false
+    instant: false
+    interval: ''
+    legendFormat: DRAM {{pod_name}}
+    refId: C
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    expr: ''
+    hide: false
+    legendFormat: __auto
+    range: true
+    refId: D
+  - datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    editorMode: code
+    expr: "sum by (pod_namespace) (sum_over_time(pod_curr_energy_in_pkg_millijoule[24h])*15/3/3600000000)\n\n"
+    hide: false
+    legendFormat: __auto
+    range: true
+    refId: E
+  title: Total Pod Energy Consumption (kW) in 24hrs
+  transformations: []
+  type: timeseries
+- datasource:
+    type: prometheus
+    uid: 7tfubjI4k
+  description: ''
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      mappings: []
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: "#EAB839"
+          value: 1.5
+        - color: red
+          value: 3
+    overrides: []
+  gridPos:
+    h: 9
+    w: 12
+    x: 0
+    y: 35
+  id: 5
+  options:
+    displayMode: gradient
+    minVizHeight: 10
+    minVizWidth: 0
+    orientation: vertical
+    reduceOptions:
+      calcs:
+      - lastNotNull
+      fields: ''
+      values: false
+    showUnfilled: true
+    text: {}
+  pluginVersion: 9.1.0
+  targets:
+  - datasource:
+      type: prometheus
+      uid: "${DS_PROMETHEUS}"
+    editorMode: code
+    exemplar: true
+    expr: rate(pod_curr_energy_millijoule{pod_namespace="$namespace"}[24h])/(20*60*24)/3600000000
+    hide: false
+    interval: ''
+    legendFormat: "{{pod_name}}"
+    range: true
+    refId: A
+  title: Total Pod Energy Consumption (kW) in $namespace in 24hrs
+  type: bargauge
+- datasource: {}
+  description: ''
+  fieldConfig:
+    defaults:
+      color:
+        mode: thresholds
+      custom:
+        align: auto
+        displayMode: color-text
+        filterable: false
+        inspect: false
+      mappings: []
+      thresholds:
+        mode: absolute
+        steps:
+        - color: green
+          value:
+        - color: "#EAB839"
+          value: 10
+        - color: red
+          value: 20
+    overrides:
+    - matcher:
+        id: byName
+        options: pod_namespace
+      properties:
+      - id: displayName
+        value: Namespace
+      - id: custom.filterable
+        value: true
+    - matcher:
+        id: byName
+        options: Value
+      properties:
+      - id: displayName
+        value: kW
+      - id: custom.displayMode
+        value: lcd-gauge
+      - id: color
+        value:
+          mode: continuous-GrYlRd
+  gridPos:
+    h: 9
+    w: 12
+    x: 12
+    y: 35
+  id: 6
+  maxPerRow: 8
+  options:
+    footer:
+      fields: ''
+      reducer:
+      - sum
+      show: false
+    showHeader: true
+    sortBy:
+    - desc: true
+      displayName: kW
+  pluginVersion: 9.1.0
+  repeatDirection: h
+  targets:
+  - datasource:
+      type: prometheus
+      uid: "${DS_PROMETHEUS}"
+    editorMode: code
+    exemplar: true
+    expr: "sum by (pod_namespace) (\n    rate(pod_curr_energy_millijoule[24h])/(20*60*24)/3600000000\n) "
+    format: table
+    hide: false
+    instant: true
+    interval: ''
+    intervalFactor: 1
+    legendFormat: ''
+    refId: A
+  title: Total Energy Consumption (kW) by Namespace in 24hrs
+  type: table
+refresh: 5s
+schemaVersion: 37
+style: dark
+tags:
+- kepler
+- energy consumption
+templating:
+  list:
+  - current:
+      selected: true
+      text: system
+      value: system
+    datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    definition: label_values(pod_energy_stat, pod_namespace)
+    description: Namespace for pods to choose
+    hide: 0
+    includeAll: false
+    label: Namespace
+    multi: false
+    name: namespace
+    options: []
+    query:
+      query: label_values(pod_energy_stat, pod_namespace)
+      refId: StandardVariableQuery
+    refresh: 1
+    regex: ''
+    skipUrlSync: false
+    sort: 0
+    tagValuesQuery: ''
+    tagsQuery: ''
+    type: query
+    useTags: false
+  - current:
+      selected: true
+      text: system_processes
+      value: system_processes
+    datasource:
+      type: prometheus
+      uid: 7tfubjI4k
+    definition: label_values(pod_energy_stat{pod_namespace="$namespace"}, pod_name)
+    hide: 0
+    includeAll: false
+    label: Pod
+    multi: false
+    name: pod
+    options: []
+    query:
+      query: label_values(pod_energy_stat{pod_namespace="$namespace"}, pod_name)
+      refId: StandardVariableQuery
+    refresh: 1
+    regex: ''
+    skipUrlSync: false
+    sort: 0
+    tagValuesQuery: ''
+    tagsQuery: ''
+    type: query
+    useTags: false
+  - hide: 2
+    name: coal
+    query: '2.23'
+    skipUrlSync: false
+    type: constant
+  - hide: 2
+    name: natural_gas
+    query: '0.91'
+    skipUrlSync: false
+    type: constant
+  - hide: 2
+    name: petroleum
+    query: '2.13'
+    skipUrlSync: false
+    type: constant
+time:
+  from: now-5m
+  to: now
+timepicker: {}
+timezone: ''
+title: Kepler Exporter Dashboard
+uid: feedc0ffee
+version: 6
+weekStart: ''

--- a/prometheus-telegraf/11-service-account.yaml
+++ b/prometheus-telegraf/11-service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: telegraf
+    app.kubernetes.io/name: prometheus-telegraf-custom
+  name: prometheus-telegraf-custom
+  namespace: newton

--- a/prometheus-telegraf/12-cluster-role-binding.yaml
+++ b/prometheus-telegraf/12-cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: telegraf
+    app.kubernetes.io/name: prometheus-telegraf-custom
+  name: prometheus-telegraf-custom
+  namespace: newton
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-telegraf
+subjects:
+- kind: ServiceAccount
+  name: prometheus-telegraf-custom
+  namespace: newton

--- a/prometheus-telegraf/13-prometheus-telegraf-idrac-ds.yaml
+++ b/prometheus-telegraf/13-prometheus-telegraf-idrac-ds.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: telegraf
+    app.kubernetes.io/name: prometheus-telegraf-custom
+  name: prometheus-telegraf-custom
+  namespace: newton
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: telegraf
+      app.kubernetes.io/name: prometheus-telegraf-custom
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: telegraf
+      labels:
+        app.kubernetes.io/component: telegraf
+        app.kubernetes.io/name: prometheus-telegraf-custom
+    spec:
+      volumes:
+        - name: telegraf-config-volume
+          configMap:
+            name: telegraf-config
+            defaultMode: 420
+      containers:
+        image: telegraf:1.22
+        imagePullPolicy: IfNotPresent
+        name: telegraf
+        ports:
+        # WARNING: This is open to everyone 
+        - containerPort: 9126
+          name: telegraf
+        volumeMounts:
+          - name: telegraf-config-volume
+            readOnly: true
+            mountPath: /etc/telegraf/telegraf.conf
+            subPath: telegraf.conf
+        resources:
+          requests:
+            cpu: 4m
+            memory: 32Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError       
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Always
+      securityContext: {}
+      serviceAccount: prometheus-telegraf-custom
+      serviceAccountName: prometheus-telegraf-custom
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/prometheus-telegraf/14-telegraf-service.yaml
+++ b/prometheus-telegraf/14-telegraf-service.yaml
@@ -1,0 +1,17 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: telegraf
+    app.kubernetes.io/name: prometheus-telegraf-custom
+  name: prometheus-telegraf-custom
+spec:
+  ports:
+  - name: telegraf
+    port: 9126
+    protocol: TCP
+    targetPort: 9126
+  selector:
+    app.kubernetes.io/component: telegraf
+    app.kubernetes.io/name: prometheus-telegraf-custom

--- a/prometheus-telegraf/15-service-monitor.yaml
+++ b/prometheus-telegraf/15-service-monitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: telegraf
+    app.kubernetes.io/name: prometheus-telegraf-custom
+  name: prometheus-telegraf-custom
+  namespace: newton #or netwon-idracs or newton-develop
+spec:
+  endpoints:
+  - interval: 5s
+    port: telegraf
+    scheme: http
+    relabelings:
+    - action: replace
+      regex: (.*)
+      replacement: $1
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: instance
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: telegraf
+      app.kubernetes.io/name: prometheus-telegraf-custom

--- a/prometheus-telegraf/16-configmap.yaml
+++ b/prometheus-telegraf/16-configmap.yaml
@@ -1,0 +1,253 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: telegraf-config
+  namespace: newton
+  uid: 596085fc-0ea7-45ca-9da0-d82a11bf4d23
+  resourceVersion: '9860531'
+  creationTimestamp: '2022-09-30T06:05:32Z'
+  labels:
+    kubernetes.io/metadata.name: newton
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: v1
+      time: '2022-09-30T06:23:13Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:data':
+          .: {}
+          'f:telegraf.conf': {}
+        'f:metadata':
+          'f:labels':
+            .: {}
+            'f:kubernetes.io/metadata.name': {}
+data:
+  telegraf.conf: |-
+    [[processors.regex]]
+      [[processors.regex.fields]]
+        key = "log-dates"
+        pattern = "^(?P<YYYY>\\d{4})(?P<MM>\\d{2})(?P<DD>\\d{2})(?P<HH>\\d{2})(?P<mm>\\d{2})(?P<ss>\\d{2})\\.(?P<SSSSSS>\\d{6})(?P<ZZ>[-+]\\d{3,4})$"
+        replacement = "${YYYY}-${MM}-${DD} ${HH}:${mm}:${ss}"
+
+    [[inputs.snmp]]
+      agents = [ "udp://192.168.52.167:161" ,
+                 "udp://192.168.52.168:161" ,
+                 "udp://192.168.52.169:161", 
+                 "udp://192.168.52.150:161" ,
+                 "udp://192.168.52.151:161" ,
+                 "udp://192.168.52.173:161",
+                 "udp://192.168.52.172:161" ]
+                 #w3                            #w4                           #w2                             #SNO
+     #agents = [ "udp://192.168.52.150:161" , "udp://192.168.52.151:161" , "udp://192.168.52.173:161", "udp://192.168.52.172:161"]
+      version = 1
+      community = "public"
+      name = "idrac-hosts"
+
+      [[inputs.snmp.field]]
+        name = "system-name"
+        oid  = ".1.3.6.1.2.1.1.5.0"
+        is_tag = true
+
+      [[inputs.snmp.field]]
+        name = "system-osname"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.3.6.0"
+
+      [[inputs.snmp.field]]
+        name = "system-osversion"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.3.14.0"
+
+      [[inputs.snmp.field]]
+        name = "system-model"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.3.12.0"
+
+      [[inputs.snmp.field]]
+        name = "idrac-url"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.1.6.0"
+
+      [[inputs.snmp.field]]
+        name = "power-state"
+        oid  = ".1.3.6.1.4.1.674.10892.5.2.4.0"
+
+      [[inputs.snmp.field]]
+        name = "system-uptime"
+        oid  = ".1.3.6.1.4.1.674.10892.5.2.5.0"
+
+      [[inputs.snmp.field]]
+        name = "system-servicetag"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.3.2.0"
+
+      [[inputs.snmp.field]]
+        name = "system-globalstatus"
+        oid  = ".1.3.6.1.4.1.674.10892.5.2.1.0"
+
+      [[inputs.snmp.table]]
+        name = "idrac-hosts"
+        inherit_tags = [ "system-name" , "disks-name" ]
+
+        [[inputs.snmp.table.field]]
+          name = "bios-version"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.50.1.8"
+
+        [[inputs.snmp.table.field]]
+          name = "raid-batterystate"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.15.1.4"
+
+        [[inputs.snmp.table.field]]
+          name = "intrusion-sensor"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.70.1.6"
+
+        [[inputs.snmp.table.field]]
+          name = "disks-mediatype"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.35"
+
+        [[inputs.snmp.table.field]]
+          name = "disks-state"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.4"
+
+        [[inputs.snmp.table.field]]
+          name = "disks-predictivefail"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.31"
+
+        [[inputs.snmp.table.field]]
+          name = "disks-capacity"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.11"
+
+        [[inputs.snmp.table.field]]
+          name = "disks-name"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.2"
+          is_tag = true
+
+        [[inputs.snmp.table.field]]
+          name = "memory-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.200.10.1.27"
+
+        [[inputs.snmp.table.field]]
+          name = "storage-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.2.3"
+
+        [[inputs.snmp.table.field]]
+          name = "temp-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.200.10.1.63"
+
+        [[inputs.snmp.table.field]]
+          name = "psu-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.200.10.1.9"
+
+        [[inputs.snmp.table.field]]
+          name = "log-dates"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.40.1.8"
+
+        [[inputs.snmp.table.field]]
+          name = "log-entry"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.40.1.5"
+
+        [[inputs.snmp.table.field]]
+          name = "log-severity"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.40.1.7"
+
+        [[inputs.snmp.table.field]]
+          name = "log-number"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.40.1.2"
+          is_tag = true
+
+        [[inputs.snmp.table.field]]
+          name = "nic-name"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.1100.90.1.30"
+          is_tag = true
+
+        [[inputs.snmp.table.field]]
+          name = "nic-vendor"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.1100.90.1.7"
+
+        [[inputs.snmp.table.field]]
+          name = "nic-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.1100.90.1.4"
+
+        [[inputs.snmp.table.field]]
+          name = "nic-current_mac"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.1100.90.1.15"
+          conversion = "hwaddr"
+
+      [[inputs.snmp.field]]
+        name = "fan1-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.1"
+
+      [[inputs.snmp.field]]
+        name = "fan2-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.2"
+
+      [[inputs.snmp.field]]
+        name = "fan3-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.3"
+
+      [[inputs.snmp.field]]
+        name = "fan4-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.4"
+
+      [[inputs.snmp.field]]
+        name = "fan5-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.5"
+
+      [[inputs.snmp.field]]
+        name = "fan6-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.6"
+
+      [[inputs.snmp.field]]
+        name = "inlet-temp"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.1"
+
+      [[inputs.snmp.field]]
+        name = "exhaust-temp"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.2"
+
+      [[inputs.snmp.field]]
+        name = "cpu1-temp"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.3"
+
+      [[inputs.snmp.field]]
+        name = "cpu2-temp"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.4"
+
+      [[inputs.snmp.field]]
+        name = "cmos-batterystate"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.600.50.1.6.1.1"
+
+      [[inputs.snmp.field]]
+        name = "system-watts"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.600.30.1.6.1.3"
+    [[outputs.file]]
+      files = ["stdout", "/tmp/metrics.out"]
+
+    [[outputs.prometheus_client]]
+        ## Address to listen on.
+        listen = "0.0.0.0:9090"
+
+        ## Use HTTP Basic Authentication.
+        # basic_username = "Foo"
+        # basic_password = "Bar"
+        metric_version = 2
+        ## If set, the IP Ranges which are allowed to access metrics.
+        ##   ex: ip_range = ["192.168.0.0/24", "192.168.1.0/30"]
+        # ip_range = []
+
+        ## Path to publish the metrics on.
+        path = "/metrics"
+
+        ## Expiration interval for each metric. 0 == no expiration
+        #expiration_interval = "0s"
+
+        ## Collectors to enable, valid entries are "gocollector" and "process".
+        ## If unset, both are enabled.
+        # collectors_exclude = ["gocollector", "process"]
+
+        ## Send string metrics as Prometheus labels.
+        ## Unless set to false all string metrics will be sent as labels.
+        # string_as_label = true
+
+        ## If set, enable TLS with the given certificate.
+        # tls_cert = "/etc/ssl/telegraf.crt"
+        # tls_key = "/etc/ssl/telegraf.key"
+
+        ## Export metric collection time.
+        export_timestamp = true

--- a/prometheus-telegraf/16-configmap.yaml
+++ b/prometheus-telegraf/16-configmap.yaml
@@ -3,25 +3,9 @@ apiVersion: v1
 metadata:
   name: telegraf-config
   namespace: newton
-  uid: 596085fc-0ea7-45ca-9da0-d82a11bf4d23
-  resourceVersion: '9860531'
-  creationTimestamp: '2022-09-30T06:05:32Z'
   labels:
-    kubernetes.io/metadata.name: newton
-  managedFields:
-    - manager: Mozilla
-      operation: Update
-      apiVersion: v1
-      time: '2022-09-30T06:23:13Z'
-      fieldsType: FieldsV1
-      fieldsV1:
-        'f:data':
-          .: {}
-          'f:telegraf.conf': {}
-        'f:metadata':
-          'f:labels':
-            .: {}
-            'f:kubernetes.io/metadata.name': {}
+    app.kubernetes.io/component: telegraf
+    app.kubernetes.io/name: prometheus-telegraf-custom
 data:
   telegraf.conf: |-
     [[processors.regex]]

--- a/prometheus-telegraf/deploy.sh
+++ b/prometheus-telegraf/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+oc create deployment telegraf-idrac
+oc tag telegraf-idrac:$IDRACNAME telegraf-idrac:latest
+oc create configmap telegraf-idrac-$IDRACNAME \
+    --from-file=telegraf.conf 

--- a/prometheus-telegraf/kustomization.yaml
+++ b/prometheus-telegraf/kustomization.yaml
@@ -1,5 +1,5 @@
 commonLabels:
-  telco.shift.zone/app: newton #or netwon-develop
+  telco.shift.zone/app: newton #or newton-develop or newton-idracs
 
 resources:
 # - optional-namespace.yaml

--- a/prometheus-telegraf/kustomization.yaml
+++ b/prometheus-telegraf/kustomization.yaml
@@ -1,0 +1,10 @@
+commonLabels:
+  telco.shift.zone/app: newton
+
+resources:
+# - optional-namespace.yaml
+- 11-serivce-account.yaml
+- 12-cluster-role-binding.yaml
+- 13-prometheus-telegraf-idrac-ds.yaml
+- 14-telegraf-service.yaml
+- 15-service-monitor.yaml

--- a/prometheus-telegraf/kustomization.yaml
+++ b/prometheus-telegraf/kustomization.yaml
@@ -1,5 +1,5 @@
 commonLabels:
-  telco.shift.zone/app: newton
+  telco.shift.zone/app: newton #or netwon-develop
 
 resources:
 # - optional-namespace.yaml

--- a/prometheus-telegraf/optional-namespace.yaml
+++ b/prometheus-telegraf/optional-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+  name: newton-develop #or netwon-idracs
+spec: {}

--- a/prometheus-telegraf/telegraf.conf
+++ b/prometheus-telegraf/telegraf.conf
@@ -1,0 +1,176 @@
+    [[processors.regex]]
+      [[processors.regex.fields]]
+        key = "log-dates"
+        pattern = "^(?P<YYYY>\\d{4})(?P<MM>\\d{2})(?P<DD>\\d{2})(?P<HH>\\d{2})(?P<mm>\\d{2})(?P<ss>\\d{2})\\.(?P<SSSSSS>\\d{6})(?P<ZZ>[-+]\\d{3,4})$"
+        replacement = "${YYYY}-${MM}-${DD} ${HH}:${mm}:${ss}"
+    [[inputs.snmp]]
+      agents = [ "udp://192.168.52.167:161" ,
+                 "udp://192.168.52.168:161" ,
+                 "udp://192.168.52.169:161", 
+                 "udp://192.168.52.150:161" ,
+                 "udp://192.168.52.151:161" ,
+                 "udp://192.168.52.173:161",
+                 "udp://192.168.52.172:161" ]
+                 #w3                            #w4                           #w2                             #SNO
+     #agents = [ "udp://192.168.52.150:161" , "udp://192.168.52.151:161" , "udp://192.168.52.173:161", "udp://192.168.52.172:161"]
+      version = 1
+      community = "public"
+      name = "idrac-hosts"
+      [[inputs.snmp.field]]
+        name = "system-name"
+        oid  = ".1.3.6.1.2.1.1.5.0"
+        is_tag = true
+      [[inputs.snmp.field]]
+        name = "system-osname"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.3.6.0"
+      [[inputs.snmp.field]]
+        name = "system-osversion"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.3.14.0"
+      [[inputs.snmp.field]]
+        name = "system-model"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.3.12.0"
+      [[inputs.snmp.field]]
+        name = "idrac-url"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.1.6.0"
+      [[inputs.snmp.field]]
+        name = "power-state"
+        oid  = ".1.3.6.1.4.1.674.10892.5.2.4.0"
+      [[inputs.snmp.field]]
+        name = "system-uptime"
+        oid  = ".1.3.6.1.4.1.674.10892.5.2.5.0"
+      [[inputs.snmp.field]]
+        name = "system-servicetag"
+        oid  = ".1.3.6.1.4.1.674.10892.5.1.3.2.0"
+      [[inputs.snmp.field]]
+        name = "system-globalstatus"
+        oid  = ".1.3.6.1.4.1.674.10892.5.2.1.0"
+      [[inputs.snmp.table]]
+        name = "idrac-hosts"
+        inherit_tags = [ "system-name" , "disks-name" ]
+        [[inputs.snmp.table.field]]
+          name = "bios-version"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.50.1.8"
+        [[inputs.snmp.table.field]]
+          name = "raid-batterystate"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.15.1.4"
+        [[inputs.snmp.table.field]]
+          name = "intrusion-sensor"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.70.1.6"
+        [[inputs.snmp.table.field]]
+          name = "disks-mediatype"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.35"
+        [[inputs.snmp.table.field]]
+          name = "disks-state"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.4"
+        [[inputs.snmp.table.field]]
+          name = "disks-predictivefail"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.31"
+        [[inputs.snmp.table.field]]
+          name = "disks-capacity"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.11"
+        [[inputs.snmp.table.field]]
+          name = "disks-name"
+          oid = ".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.2"
+          is_tag = true
+        [[inputs.snmp.table.field]]
+          name = "memory-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.200.10.1.27"
+        [[inputs.snmp.table.field]]
+          name = "storage-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.2.3"
+        [[inputs.snmp.table.field]]
+          name = "temp-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.200.10.1.63"
+        [[inputs.snmp.table.field]]
+          name = "psu-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.200.10.1.9"
+        [[inputs.snmp.table.field]]
+          name = "log-dates"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.40.1.8"
+        [[inputs.snmp.table.field]]
+          name = "log-entry"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.40.1.5"
+        [[inputs.snmp.table.field]]
+          name = "log-severity"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.40.1.7"
+        [[inputs.snmp.table.field]]
+          name = "log-number"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.300.40.1.2"
+          is_tag = true
+        [[inputs.snmp.table.field]]
+          name = "nic-name"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.1100.90.1.30"
+          is_tag = true
+        [[inputs.snmp.table.field]]
+          name = "nic-vendor"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.1100.90.1.7"
+        [[inputs.snmp.table.field]]
+          name = "nic-status"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.1100.90.1.4"
+        [[inputs.snmp.table.field]]
+          name = "nic-current_mac"
+          oid = ".1.3.6.1.4.1.674.10892.5.4.1100.90.1.15"
+          conversion = "hwaddr"
+      [[inputs.snmp.field]]
+        name = "fan1-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.1"
+      [[inputs.snmp.field]]
+        name = "fan2-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.2"
+      [[inputs.snmp.field]]
+        name = "fan3-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.3"
+      [[inputs.snmp.field]]
+        name = "fan4-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.4"
+      [[inputs.snmp.field]]
+        name = "fan5-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.5"
+      [[inputs.snmp.field]]
+        name = "fan6-speed"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.6"
+      [[inputs.snmp.field]]
+        name = "inlet-temp"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.1"
+      [[inputs.snmp.field]]
+        name = "exhaust-temp"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.2"
+      [[inputs.snmp.field]]
+        name = "cpu1-temp"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.3"
+      [[inputs.snmp.field]]
+        name = "cpu2-temp"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.4"
+      [[inputs.snmp.field]]
+        name = "cmos-batterystate"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.600.50.1.6.1.1"
+      [[inputs.snmp.field]]
+        name = "system-watts"
+        oid  = ".1.3.6.1.4.1.674.10892.5.4.600.30.1.6.1.3"
+    [[outputs.file]]
+      files = ["stdout", "/tmp/metrics.out"]
+    [[outputs.prometheus_client]]
+        ## Address to listen on.
+        listen = "0.0.0.0:9090"
+        ## Use HTTP Basic Authentication.
+        # basic_username = "Foo"
+        # basic_password = "Bar"
+        metric_version = 2
+        ## If set, the IP Ranges which are allowed to access metrics.
+        ##   ex: ip_range = ["192.168.0.0/24", "192.168.1.0/30"]
+        # ip_range = []
+        ## Path to publish the metrics on.
+        path = "/metrics"
+        ## Expiration interval for each metric. 0 == no expiration
+        #expiration_interval = "0s"
+        ## Collectors to enable, valid entries are "gocollector" and "process".
+        ## If unset, both are enabled.
+        # collectors_exclude = ["gocollector", "process"]
+        ## Send string metrics as Prometheus labels.
+        ## Unless set to false all string metrics will be sent as labels.
+        # string_as_label = true
+        ## If set, enable TLS with the given certificate.
+        # tls_cert = "/etc/ssl/telegraf.crt"
+        # tls_key = "/etc/ssl/telegraf.key"
+        ## Export metric collection time.
+        export_timestamp = true


### PR DESCRIPTION
Telegraf Deployment within 'newton' namespace (configurable for newton-dev or newton-idracs
Telegraf Daemonset sharing the same Configmap (contains telegraf.conf mapped to volume)
Telegraf.conf (idrac input plugin (cpu output, temp, idrac uptime, power output), prometheus client output config [ this streams the idrac input to be accessible for Openshift User-Defined Monitoring])
  - Metrics start with ```idrac_hosts_$METRIC_NAME```
  - Grafana Dashboard (WIP) Convert InfluxQL SELECT to PromQL selectors (sum(), application_error_count{area="x"} )
  - If labels are implemented then might have to modify telegraf.conf Prometheus client config for labels
  - Lables are optimal